### PR TITLE
feat: Add visibility controls for hand tracking overlay

### DIFF
--- a/Talking Fingers.xcodeproj/project.pbxproj
+++ b/Talking Fingers.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Talking Fingers/Talking Fingers.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = N7JQF9LRA3;
+				DEVELOPMENT_TEAM = X2P38446QQ;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
@@ -477,7 +477,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.nikola.talking-fingers";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.nikola.talking-fingers1";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
@@ -502,7 +502,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Talking Fingers/Talking Fingers.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = N7JQF9LRA3;
+				DEVELOPMENT_TEAM = X2P38446QQ;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
@@ -537,7 +537,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.nikola.talking-fingers";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.nikola.talking-fingers1";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;

--- a/Talking Fingers/Vision/Views/CameraView_iOS.swift
+++ b/Talking Fingers/Vision/Views/CameraView_iOS.swift
@@ -27,6 +27,36 @@ struct CameraView: View {
         }
         return dict
     }()
+    
+    @State private var dotsVisibility: Bool = true
+    @State private var handOutlineVisibility: Bool = true
+    @State private var handSkeletonVisibility: Bool = true
+    
+    // Store all joint connections for drawing lines
+    let handConnections: [(VNHumanHandPoseObservation.JointName, VNHumanHandPoseObservation.JointName)] = [
+        // Thumb
+        (.wrist, .thumbCMC), (.thumbCMC, .thumbMP), (.thumbMP, .thumbIP), (.thumbIP, .thumbTip),
+        // Index
+        (.wrist, .indexMCP), (.indexMCP, .indexPIP), (.indexPIP, .indexDIP), (.indexDIP, .indexTip),
+        // Middle
+        (.wrist, .middleMCP), (.middleMCP, .middlePIP), (.middlePIP, .middleDIP), (.middleDIP, .middleTip),
+        // Ring
+        (.wrist, .ringMCP), (.ringMCP, .ringPIP), (.ringPIP, .ringDIP), (.ringDIP, .ringTip),
+        // Little
+        (.wrist, .littleMCP), (.littleMCP, .littlePIP), (.littlePIP, .littleDIP), (.littleDIP, .littleTip)
+    ]
+    
+    // Store points to create polygon for hand (edges)
+    let perimeterJoints: [VNHumanHandPoseObservation.JointName] = [
+        .wrist,
+        .thumbCMC, .thumbMP, .thumbIP, .thumbTip,
+        .indexTip,
+        .middleTip,
+        .ringTip,
+        .littleTip,
+        .littleDIP, .littlePIP, .littleMCP,
+        .wrist
+    ]
 
     var body: some View {
         ZStack {
@@ -42,19 +72,71 @@ struct CameraView: View {
             }
 
             GeometryReader { geo in
+                
+                // Render hand outline
+                if handOutlineVisibility {
+                    let points = perimeterJoints.compactMap { jointName -> CGPoint? in
+                        guard let point = try? hand?.recognizedPoint(jointName),
+                              point.confidence > 0.5 else { return nil }
+                        return cameraVM.convertVisionPointToScreenPosition(visionPoint: point.location, viewSize: geo.size)
+                    }
+                    
+                    if points.count > 3 {
+                        Path { path in
+                            path.addLines(points)
+                            path.closeSubpath()
+                        }
+                        .fill(Color.green.opacity(0.3))
+                        .stroke(Color.green, lineWidth: 2)
+                    }
+                }
+                
+                // Render labels (and points if turned visible)
                 ForEach(JointsSheetView.jointLabels.filter { jointVisibility[$0.name] == true },
                         id: \.name) { joint in
                     if let point = try? hand?.recognizedPoint(joint.name),
                        point.confidence > 0.5 {
                         let pos = cameraVM.convertVisionPointToScreenPosition(
                             visionPoint: point.location, viewSize: geo.size)
-                        Text(joint.label)
-                            .font(.caption2)
-                            .padding(4)
-                            .background(.ultraThinMaterial, in: Capsule())
-                            .position(pos)
+                        ZStack {
+                            Text(joint.label)
+                                .font(.caption2)
+                                .padding(4)
+                                .background(.ultraThinMaterial, in: Capsule())
+                                .position(pos)
+                            
+                            // Only render if dots turned visisble
+                            if (dotsVisibility) {
+                                Circle()
+                                        .fill(Color.white)
+                                        .frame(width: 7, height: 7)
+                                        .position(pos)
+                            }
+                        }
                     }
                 }
+                
+                // Render hand skeleton
+                if handSkeletonVisibility {
+                    Path { path in
+                        for connection in handConnections {
+                            // Draw if both points are visible
+                            if let p1 = try? hand?.recognizedPoint(connection.0),
+                               let p2 = try? hand?.recognizedPoint(connection.1),
+                               p1.confidence > 0.5, p2.confidence > 0.5,
+                               jointVisibility[connection.0] == true, jointVisibility[connection.1] == true {
+                                
+                                let start = cameraVM.convertVisionPointToScreenPosition(visionPoint: p1.location, viewSize: geo.size)
+                                let end = cameraVM.convertVisionPointToScreenPosition(visionPoint: p2.location, viewSize: geo.size)
+                                
+                                path.move(to: start)
+                                path.addLine(to: end)
+                            }
+                        }
+                    }
+                    .stroke(Color.blue.opacity(0.6), lineWidth: 3)
+                }
+                
             }
         }
         .onAppear {
@@ -69,7 +151,7 @@ struct CameraView: View {
             cameraVM.stop()
         }
         .sheet(isPresented: $showJointsSheet) {
-            JointsSheetView(jointVisibility: $jointVisibility)
+            JointsSheetView(jointVisibility: $jointVisibility, dotsVisibility: $dotsVisibility, handOutlineVisibility: $handOutlineVisibility, handSkeletonVisibility: $handSkeletonVisibility)
         }
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {

--- a/Talking Fingers/Vision/Views/JointsSheetView.swift
+++ b/Talking Fingers/Vision/Views/JointsSheetView.swift
@@ -12,6 +12,9 @@ import Vision
 struct JointsSheetView: View {
     @Environment(\.dismiss) var dismiss
     @Binding var jointVisibility: [VNHumanHandPoseObservation.JointName: Bool]
+    @Binding var dotsVisibility: Bool
+    @Binding var handOutlineVisibility: Bool
+    @Binding var handSkeletonVisibility: Bool
 
     // Human-readable labels for each joint
     static let jointLabels: [(name: VNHumanHandPoseObservation.JointName, label: String)] = [
@@ -41,6 +44,23 @@ struct JointsSheetView: View {
     var body: some View {
         VStack {
             List {
+                // Dots toggle
+                Toggle("Show Dots", isOn: $dotsVisibility)
+                // Hand outline toggle
+                Toggle("Show Hand Outline", isOn: $handOutlineVisibility)
+                // Hand skeleton
+                Toggle("Show Hand Skeleton", isOn: $handSkeletonVisibility)
+                // All joints toggle
+                Toggle("Toggle All Joints", isOn: Binding(
+                    get: {
+                        Self.jointLabels.allSatisfy { binding(for: $0.name).wrappedValue }
+                    },
+                    set: { newValue in
+                        for joint in Self.jointLabels {
+                            binding(for: joint.name).wrappedValue = newValue
+                        }
+                    }
+                ))
                 ForEach(Self.jointLabels, id: \.name) { joint in
                     Toggle(joint.label, isOn: binding(for: joint.name))
                 }
@@ -64,12 +84,18 @@ struct JointsSheetView: View {
 }
 
 #Preview {
-    @Previewable @State var preview: [VNHumanHandPoseObservation.JointName: Bool] = [
+    @Previewable @State var previewJoints: [VNHumanHandPoseObservation.JointName: Bool] = [
         .thumbTip: true,
         .indexTip: false
     ]
+    @Previewable @State var previewDots: Bool = true
+    @Previewable @State var previewHandOutline: Bool = true
+    @Previewable @State var previewHandSkeleton: Bool = true
     NavigationStack {
-        JointsSheetView(jointVisibility: $preview)
+        JointsSheetView(jointVisibility: $previewJoints,
+        dotsVisibility: $previewDots,
+        handOutlineVisibility: $previewHandOutline,
+        handSkeletonVisibility: $previewHandSkeleton)
     }
 }
 


### PR DESCRIPTION
**Overview**
Adds a set of toggle controls to customize the hand-tracking overlay. This allows users to adjust the level of visual feedback from their hands.

<img width="287" height="537" alt="image" src="https://github.com/user-attachments/assets/48114855-0b92-42d7-85b0-1c09c2e67e46" />
<img width="287" height="588" alt="IMG_1482" src="https://github.com/user-attachments/assets/0b97cc1f-6e40-40fa-923a-c88ec8ffccc9" />

**Changes**
- Master Toggle: Added functionality to show/hide all labels (+ markers if toggled) for joints in the hand.
- Joint Markers: Added toggle for joint "dots" visibility.
- Skeleton View: Added toggle for the connecting lines between joints.
- Hand Outline: Added toggle for the green hand outline/polygon.

**Technical Notes**
- **State Management**: Implemented `@State` variables in the parent view and passed them as `@Binding` to JointsSheetView to manage visibility states for hand joints, skeleton lines, and the hand outline.
- **Conditional Rendering**: Added logic in CameraView_iOS to conditionally render the dots, lines, and polygons based on these new state flags.
 - **UI Implementation**: Updated JointsSheetView with new Toggle controls to allow user hand-display customization.

**How to Test**
1. Launch the app and enter the vision tab.
2. Open the vision settings in the top right.
3. Go through each toggle to ensure the UI updates in real-time.
4. Check that toggling "Master Toggle" always shows/hides all joints.
