### PR TITLE
feat: FilterReferences function to filter low confidence poses

### DIFF
--- a/Talking Fingers/Vision/ViewModels/CameraVM.swift
+++ b/Talking Fingers/Vision/ViewModels/CameraVM.swift
@@ -133,4 +133,21 @@ class CameraVM: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
         
         return CGPoint(x: x, y: y)
     }
+    
+    // Filter frames
+    func filterReferences(for references: [(TimeInterval, VNHumanHandPoseObservation)]) -> [(TimeInterval, VNHumanHandPoseObservation)] {
+        return references.filter({t -> Bool in
+            guard let allPoints = try? t.1.recognizedPoints(.all) else {
+                return false
+            }
+            
+            let joints = allPoints.values.filter { $0.confidence > 0.3 }
+            
+            guard joints.count >= 12 else {
+                return false
+            }
+
+            return joints.reduce(0) { $0 + $1.confidence } / Float(joints.count) >= 0.7
+        })
+    }
 }


### PR DESCRIPTION
**Overview**
Implements a quality-control filter for hand tracking data to improve pose accuracy. It removes low-confidence observations and frames with insufficient joint data.

**Changes**
- Data Filtering: Added filterReferences(for:) to filter low-quality VNHumanHandPoseObservation data.
- Thresholds:
    - Minimum 12 joints with confidence > 0.3.
    - Calculated average confidence of those joints must be >= 0.7.

**Technical Notes**
- Uses recognizedPoints(.all) to evaluate the full hand model
- Uses filter method to find joints with confidence > 0.3
- Uses filter method to return the correct array of tuples: [(TimeInterval, VNHumanHandPoseObservation)])

**How to Test**
When this function is implemented, it can be tested by:
- ensuring clear hand poses are retained in the references array
- partially hiding your hand or using poor lighting, then verifying that low-confidence frames are successfully excluded

