### PR TITLE
Window for camera feed

### DIFF
--- a/Talking Fingers/Vision/Views/CameraView_iOS.swift
+++ b/Talking Fingers/Vision/Views/CameraView_iOS.swift
@@ -66,6 +66,7 @@ struct CameraView: View {
                     // Camera "window" that holds the live feed + ALL overlays
                     ZStack {
                         CameraPreviewView(session: cameraVM.session)
+                            .ignoresSafeArea()
 
                         // IMPORTANT: GeometryReader is inside the window,
                         // so size is the window size (keeps overlays aligned).
@@ -106,7 +107,6 @@ struct CameraView: View {
             }
             .padding(.top, 12)
         }
-        .ignoresSafeArea()
         .onAppear {
             cameraVM.checkPermission()
             cameraVM.start()


### PR DESCRIPTION
Put the live camera preview into a scrollable VStack “window” and keep all hand overlays working. The preview and GeometryReader now share the same clipped rounded rectangle so dots, skeleton lines, outlines, and chirality labels stay aligned while leaving space below for future UI.