### PR TITLE
scale invariance fixes

### DIFF
--- a/Talking Fingers/Vision/ViewModels/CameraVM.swift
+++ b/Talking Fingers/Vision/ViewModels/CameraVM.swift
@@ -12,16 +12,16 @@ import CoreGraphics
 @Observable
 class CameraVM: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
     let session = AVCaptureSession() // connects camera hardware to the app
-    private let videoOutput = AVCaptureVideoDataOutput() // buffers video frames for the vision intelligence to use
+    private let videoOutput = AVCaptureVideoDataOutput() // buffers video frames for Vision
 
-    private let sessionQueue = DispatchQueue(label: "camera.session.queue") // run the camera on a background thread so it doesn't freeze UI
+    private let sessionQueue = DispatchQueue(label: "camera.session.queue") // background camera thread
 
-    // This closure will pass the vision observations back to your UI or Logic
-    var onPoseDetected: (([VNHumanHandPoseObservation]) -> Void)?
+    // This closure will pass the vision observations and an accurate frame timestamp back to UI/Logic
+    var onPoseDetected: (([VNHumanHandPoseObservation], CMTime) -> Void)?
 
     var isAuthorized = false
 
-    // Add to keep track of observations relative to camera
+    // Track mirroring for correct left/right interpretation
     var isMirrored = true
 
     override init() {
@@ -48,48 +48,46 @@ class CameraVM: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
 
     private func setupSession() {
         session.beginConfiguration()
-        defer { session.commitConfiguration() } // Always commit, even on early return
+        defer { session.commitConfiguration() }
 
-        session.sessionPreset = .hd1280x720 // 720p — clear preview without the memory cost of full 1080p
+        session.sessionPreset = .hd1280x720
 
-        guard let videoDevice = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .front), // choose front facing camera
+        guard let videoDevice = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .front),
               let videoInput = try? AVCaptureDeviceInput(device: videoDevice) else { return }
 
-        // Cap frame rate to 24 fps to balance memory/CPU with the higher resolution
+        // Cap frame rate to 24 fps
         do {
             try videoDevice.lockForConfiguration()
-            videoDevice.activeVideoMinFrameDuration = CMTime(value: 1, timescale: 24) // min = 24 fps
-            videoDevice.activeVideoMaxFrameDuration = CMTime(value: 1, timescale: 24) // max = 24 fps
+            videoDevice.activeVideoMinFrameDuration = CMTime(value: 1, timescale: 24)
+            videoDevice.activeVideoMaxFrameDuration = CMTime(value: 1, timescale: 24)
             videoDevice.unlockForConfiguration()
         } catch {
             print("Could not configure frame rate: \(error)")
         }
 
-        if session.canAddInput(videoInput) { session.addInput(videoInput) } // connect the camera input to the session
+        if session.canAddInput(videoInput) { session.addInput(videoInput) }
 
-        videoOutput.alwaysDiscardsLateVideoFrames = true // Drop frames if processing can't keep up, prevents memory buildup
-        videoOutput.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_420YpCbCr8BiPlanarFullRange] // Efficient pixel format
-        videoOutput.setSampleBufferDelegate(self, queue: DispatchQueue(label: "video.output.queue")) // process frames from the camera
-        if session.canAddOutput(videoOutput) { session.addOutput(videoOutput) } // output video output
+        videoOutput.alwaysDiscardsLateVideoFrames = true
+        videoOutput.videoSettings = [
+            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
+        ]
+        videoOutput.setSampleBufferDelegate(self, queue: DispatchQueue(label: "video.output.queue"))
+        if session.canAddOutput(videoOutput) { session.addOutput(videoOutput) }
 
-        // Ensure orientation is correct for the front camera
         if let connection = videoOutput.connection(with: .video) {
             connection.videoOrientation = .portrait
-            connection.isVideoMirrored = self.isMirrored // Mirroring makes it feel natural for sign language practice
+            connection.isVideoMirrored = self.isMirrored
         }
     }
 
     func start() {
         sessionQueue.async {
-            // Wait for authorization
             guard self.isAuthorized else { return }
 
-            // 1. Configure if needed
             if self.session.inputs.isEmpty {
                 self.setupSession()
             }
 
-            // 2. Start only if not already running
             if !self.session.isRunning {
                 self.session.startRunning()
             }
@@ -104,22 +102,22 @@ class CameraVM: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
         }
     }
 
-    // THIS IS THE BRAIN: Where Vision meets the Camera
-    // runs 24 times a second - every video frame processed here
+    // Vision + camera frame processing
     func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
-        autoreleasepool { // Free temporary Vision/CoreMedia objects each frame to prevent memory buildup
-            let handler = VNImageRequestHandler(cmSampleBuffer: sampleBuffer, orientation: .up, options: [:]) // creates a request handler
+        autoreleasepool {
+            let pts = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
 
-            let handPoseRequest = VNDetectHumanHandPoseRequest() // defines a hand pose request
-            handPoseRequest.maximumHandCount = 2 // Two hands
+            let handler = VNImageRequestHandler(cmSampleBuffer: sampleBuffer, orientation: .up, options: [:])
+
+            let handPoseRequest = VNDetectHumanHandPoseRequest()
+            handPoseRequest.maximumHandCount = 2
 
             do {
-                try handler.perform([handPoseRequest]) // analyze the hand pose
-                let observations = handPoseRequest.results ?? [] // extract results
+                try handler.perform([handPoseRequest])
+                let observations = handPoseRequest.results ?? []
 
-                // Send the hand landmarks back to the main thread for UI/Logic
                 DispatchQueue.main.async {
-                    self.onPoseDetected?(observations)
+                    self.onPoseDetected?(observations, pts)
                 }
             } catch {
                 print("Vision error: \(error)")
@@ -133,28 +131,44 @@ class CameraVM: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
         return CGPoint(x: x, y: y)
     }
 
-    // MARK: - Scale invariance / normalization
+    // Filter frames (kept from main)
+    func filterReferences(for references: [(TimeInterval, VNHumanHandPoseObservation)]) -> [(TimeInterval, VNHumanHandPoseObservation)] {
+        return references.filter({ t -> Bool in
+            guard let allPoints = try? t.1.recognizedPoints(.all) else {
+                return false
+            }
+
+            let joints = allPoints.values.filter { $0.confidence > 0.3 }
+
+            guard joints.count >= 12 else {
+                return false
+            }
+
+            return joints.reduce(0) { $0 + $1.confidence } / Float(joints.count) >= 0.7
+        })
+    }
+
+    // MARK: - Scale invariance / normalization (added)
 
     struct NormalizedHand {
         /// Points normalized into a standard unit bounding box [0,1]x[0,1]
-        /// (independent of how large the hand appears in the camera frame)
         let unitPoints: [VNHumanHandPoseObservation.JointName: CGPoint]
 
-        /// Bounding box in *Vision normalized image coords* (0..1)
+        /// Bounding box in Vision normalized image coords (0..1)
         let rawBounds: CGRect
 
         /// Uniform scale applied (1 / max(width,height))
         let scale: CGFloat
 
-        /// Translation applied before scale (i.e., subtracting minX/minY)
+        /// Translation applied before scale (subtracting minX/minY)
         let translation: CGPoint
 
         /// Optional padding to center the scaled hand within the unit box
         let padding: CGPoint
     }
 
-    /// Scale/translation normalize all landmarks so the hand fits into a standard unit bounding box.
-    /// - Important: This does NOT change your overlay rendering. Use this for recognition/features/training.
+    /// Normalize landmarks so the hand fits into a standard unit bounding box.
+    /// This does NOT affect the on-screen overlay; use for recognition/features/debugging.
     func normalizeHandToUnitBox(
         hand: VNHumanHandPoseObservation,
         joints: [VNHumanHandPoseObservation.JointName],
@@ -172,10 +186,9 @@ class CameraVM: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
             raw[j] = p.location
         }
 
-        // Need enough points to form a meaningful box
         guard raw.count >= 3 else { return nil }
 
-        // 2) Compute bounding box in Vision normalized space
+        // 2) Compute bounding box
         let xs = raw.values.map { $0.x }
         let ys = raw.values.map { $0.y }
         guard let minX = xs.min(), let maxX = xs.max(),
@@ -185,14 +198,16 @@ class CameraVM: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
         let height = max(maxY - minY, 1e-6)
         let bounds = CGRect(x: minX, y: minY, width: width, height: height)
 
-        // 3) Translate box origin to (0,0), 4) uniformly scale to fit inside 1x1
+        // 3) Translate to origin, 4) uniform scale to fit inside 1x1
         let s = 1.0 / max(width, height)
         let translation = CGPoint(x: -minX, y: -minY)
 
-        // 5) Optional centering padding so it sits in the middle of the unit box
+        // 5) optional centering padding
         let scaledW = width * s
         let scaledH = height * s
-        let padding = centerInBox ? CGPoint(x: (1 - scaledW) * 0.5, y: (1 - scaledH) * 0.5) : .zero
+        let padding = centerInBox
+        ? CGPoint(x: (1 - scaledW) * 0.5, y: (1 - scaledH) * 0.5)
+        : .zero
 
         var unit: [VNHumanHandPoseObservation.JointName: CGPoint] = [:]
         unit.reserveCapacity(raw.count)


### PR DESCRIPTION
Add hand landmark normalization so distance from the camera doesn’t change our coordinate values. For each detected hand, compute its landmark bounding box and rescale/center the points into a fixed 0–1 box, plus a small on-screen debug box to confirm it stays consistent when you move closer or farther. Changes in CameraView_iOS are just for visualization and debugging, main function is in cameravm.swift and the CameraView_iOS changes can be commented out or removed.