### PR TITLE
164 update flashcards view sequence UI

### DIFF
--- a/Talking Fingers/Flashcards/ViewModels/LearnModeVM.swift
+++ b/Talking Fingers/Flashcards/ViewModels/LearnModeVM.swift
@@ -21,7 +21,9 @@ class LearnModeVM: ObservableObject {
     var onNextCard: (() -> Void)? = nil
 
     let flashcard: FlashcardModel
-
+    
+    private let tfGreen = Color(red: 159/255, green: 192/255, blue: 122/255)
+    
     init(flashcard: FlashcardModel) {
         self.flashcard = flashcard
     }
@@ -40,15 +42,15 @@ class LearnModeVM: ObservableObject {
     }
 
     var buttonText: String {
-        state == .initial ? "Try" : "Next Word"
+        state == .initial ? "Try Signing" : "Next Word"
     }
 
     var buttonColor: Color {
-        state == .initial ? .gray : .blue
+        tfGreen
     }
 
     var bulbColor: Color {
-        state == .showingHint ? .yellow : .gray
+        state == .showingHint ? .orange : .gray.opacity(0.5)
     }
 
     var showHintButton: Bool {
@@ -56,7 +58,7 @@ class LearnModeVM: ObservableObject {
     }
 
     var showingCamera: Bool {
-        state == .practicing
+        state == .practicing || state == .showingHint
     }
 
     var showingHint: Bool {

--- a/Talking Fingers/Flashcards/ViewModels/LearnModeVM.swift
+++ b/Talking Fingers/Flashcards/ViewModels/LearnModeVM.swift
@@ -17,6 +17,8 @@ class LearnModeVM: ObservableObject {
     }
 
     @Published var state: LearnState = .initial
+    
+    var onNextCard: (() -> Void)? = nil
 
     let flashcard: FlashcardModel
 
@@ -84,5 +86,6 @@ class LearnModeVM: ObservableObject {
         print("next word")
         // reset for next flashcard later
         state = .initial
+        onNextCard?()
     }
 }

--- a/Talking Fingers/Flashcards/Views/Components/EndCardComponent.swift
+++ b/Talking Fingers/Flashcards/Views/Components/EndCardComponent.swift
@@ -1,0 +1,114 @@
+//
+//  EndCardComponent.swift
+//  Talking Fingers
+//
+//  Created by Sanvi Adusumilli on 4/16/26.
+//
+
+import SwiftUI
+
+struct EndCardComponent: View {
+    let context: StartContext
+    let total: Int
+    let onGoHome: () -> Void
+    let onGoToExercise: () -> Void
+    
+    var body: some View {
+        VStack(spacing: 24) {
+            let isLearnMode = context.title == "Learn"
+            
+            Spacer()
+            
+            if case .dailyChallenge = context {
+                ZStack {
+                    Image(systemName: "flame.fill")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(height: 120)
+                        .foregroundColor(Color(red: 0.96, green: 0.76, blue: 0.28))
+                    
+                    // can have actual streak later:
+//                    Text("3")
+//                        .font(.system(size: 45, weight: .bold))
+//                        .foregroundColor(.white)
+//                        .padding(.top, 25)
+                }
+            } else {
+                Image(systemName: context.iconName)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(height: 120)
+                    .foregroundColor(isLearnMode ? Color(red: 0.56, green: 0.72, blue: 0.44) : .black)
+            }
+            
+            if case .learn(let cat) = context {
+                Text("\(cat.displayName) Exercise")
+                    .font(.system(size: 32))
+                    .foregroundColor(.black.opacity(0.7))
+                
+                Text("Unlocked!")
+                    .font(.system(size: 35, weight: .bold))
+                    .foregroundColor(Color(red: 0.93, green: 0.78, blue: 0.50))
+                
+            } else {
+                Text("Congrats!")
+                    .font(.system(size: 36, weight: .bold))
+                
+                if case .exercise(let cat) = context {
+                    VStack(spacing: 6) {
+                        Text("You have completed")
+                            .font(.system(size: 31))
+                            .foregroundColor(.black.opacity(0.8))
+                        Text("\(cat.displayName)!")
+                            .font(.system(size: 31, weight: .bold))
+                            .foregroundColor(Color(red: 0.93, green: 0.78, blue: 0.50))
+                    }
+                }
+                
+                Spacer().frame(height: 10)
+                
+                Text("\(total)/\(total) Words Completed")
+                    .font(.subheadline)
+                    .foregroundColor(.black.opacity(0.8))
+                
+                ProgressView(value: 1.0)
+                    .tint(Color(red: 0.30, green: 0.55, blue: 0.85))
+                    .scaleEffect(y: 1.5)
+                    .padding(.horizontal, 60)
+            }
+            
+            Spacer()
+            
+            if case .learn = context {
+                Button(action: onGoToExercise) {
+                    Text("Go to Exercise")
+                        .font(.headline)
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                        .background(RoundedRectangle(cornerRadius: 16).fill(Color(red: 0.56, green: 0.72, blue: 0.44)))
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, 40)
+            }
+            
+            Button(action: onGoHome) {
+                let myColor = Color(red: 0.30, green: 0.55, blue: 0.30)
+                Text("Go Home")
+                    .font(.headline)
+                    .foregroundColor(isLearnMode ? myColor : .white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+                    .background(
+                        RoundedRectangle(cornerRadius: 16)
+                            .fill(isLearnMode ? Color(red: 0.56, green: 0.72, blue: 0.44).opacity(0.25) : Color(red: 0.56, green: 0.72, blue: 0.44))
+                    )
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, 40)
+            
+            Spacer().frame(height: 40)
+        }
+        .padding(.horizontal, 16)
+    }
+}

--- a/Talking Fingers/Flashcards/Views/Components/FlexibleStartCardComponent.swift
+++ b/Talking Fingers/Flashcards/Views/Components/FlexibleStartCardComponent.swift
@@ -1,0 +1,291 @@
+//
+//  FlexibleStartCardComponent.swift
+//  Talking Fingers
+//
+//  Created by Sanvi Adusumilli on 4/16/26.
+//
+//  Builds on StartCardComponent - works for Learn, Exercise, or Daily Challenge
+//
+
+import SwiftUI
+
+enum StartContext {
+    case learn(TermCategory)
+    case exercise(TermCategory)
+    case dailyChallenge
+    
+    var title: String {
+        switch self {
+        case .learn: return "Learn"
+        case .exercise: return "Exercise"
+        case .dailyChallenge: return "Daily Challenge"
+        }
+    }
+    
+    var subtitle: String {
+        switch self {
+        case .learn(let cat), .exercise(let cat): return cat.displayName + "!"
+        case .dailyChallenge: return ""
+        }
+    }
+    
+    var primaryButtonText: String {
+        switch self {
+        case .learn: return "Begin Learn"
+        case .exercise: return "Begin Exercise"
+        case .dailyChallenge: return "Let's Go!"
+        }
+    }
+    
+    var iconName: String {
+        switch self {
+        case .learn(let cat), .exercise(let cat):
+            switch cat {
+            case .alphabet:             return "a.square"
+            case .numbers:              return "number"
+            case .greetings:            return "hand.wave"
+            case .personalInformation:  return "person.text.rectangle"
+            case .family:               return "figure.2.and.child.holdinghands"
+            case .verbs:                return "bolt"
+            case .dateTime:             return "calendar"
+            case .feelingsEmotions:     return "heart"
+            case .locations:            return "mappin.and.ellipse"
+            case .commonDescriptors:    return "text.magnifyingglass"
+            case .commonObjects:        return "cube"
+            }
+        case .dailyChallenge:
+            return "flame.fill"
+        }
+    }
+}
+
+struct FlexibleStartCardComponent: View {
+    let context: StartContext
+    let completed: Int
+    let total: Int
+    let closeAction: () -> Void
+    
+    @State private var flashcardVM = FlashcardVM()
+    @State private var isActive: Bool = false
+    
+    @Environment(SwiftDataVM.self) private var dataVM
+
+    var progress: CGFloat {
+        CGFloat(Double(completed) / Double(max(total, 1)))
+    }
+
+    var body: some View {
+        Group {
+            if isActive {
+                switch context {
+                case .learn(let category):
+                    LearnFlow(
+                        initialCard: flashcardVM.flashcards.first ?? FlashcardModel(term: .hello, id: UUID(), category: category),
+                        targetCount: total,
+                        vm: flashcardVM
+                    ) {
+                        isActive = false
+                    }
+                    
+                case .exercise, .dailyChallenge:
+                    MultipleChoiceFlow(
+                        initialCard: flashcardVM.flashcards.first ?? FlashcardModel(term: .hello, id: UUID(), category: .greetings),
+                        imageName: context.iconName,
+                        targetCount: total,
+                        vm: flashcardVM
+                    ) {
+                        isActive = false
+                    }
+                    .environment(flashcardVM)
+                    .environment(dataVM)
+                }
+            } else {
+                startView
+            }
+        }
+    }
+
+    // MARK: - Start View UI
+    private var startView: some View {
+        ZStack {
+            VStack(spacing: 16) {
+                let lightGreen = Color(red: 0.56, green: 0.72, blue: 0.44)
+                let isDaily = context.title == "Daily Challenge"
+                Image(systemName: context.iconName)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(height: isDaily ? 120 : 150)
+                    .foregroundColor(isDaily ? .orange : lightGreen)
+                    .padding(.bottom, 10)
+
+                if case .dailyChallenge = context {
+                    Text(context.title)
+                        .font(.system(size: 42, weight: .bold))
+                        .foregroundColor(Color(red: 0.56, green: 0.72, blue: 0.44))
+                } else {
+                    Text(context.title)
+                        .font(.system(size: 40))
+                        .foregroundColor(.black.opacity(0.7))
+                    
+                    Text(context.subtitle)
+                        .font(.system(size: 42, weight: .bold))
+                        .foregroundColor(Color(red: 0.58, green: 0.72, blue: 0.85))
+                }
+
+                Text("\(completed)/\(total) Words Completed")
+                    .foregroundColor(.black)
+
+                ProgressView(value: progress)
+                    .tint(Color(red: 0.70, green: 0.80, blue: 0.90))
+                    .scaleEffect(y: 1.5)
+                    .padding(.horizontal, 60)
+
+                Spacer().frame(height: 20)
+
+                Button(action: {
+                    isActive = true
+                }) {
+                    Text(context.primaryButtonText)
+                        .font(.headline)
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(
+                            RoundedRectangle(cornerRadius: 14)
+                                .fill(Color(red: 0.56, green: 0.72, blue: 0.44))
+                        )
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, 40)
+
+                Button(action: {
+                    closeAction()
+                }) {
+                    Text("Go Home")
+                        .font(.headline)
+                        .foregroundColor(Color(red: 0.30, green: 0.55, blue: 0.30))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(
+                            RoundedRectangle(cornerRadius: 14)
+                                .fill(Color(red: 0.56, green: 0.72, blue: 0.44).opacity(0.25))
+                        )
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, 40)
+            }
+        }
+        .padding(.horizontal, 16)
+        .onAppear {
+            if flashcardVM.flashcards.isEmpty || flashcardVM.flashcards.count <= 1 {
+                 flashcardVM.flashcards = FlashcardVM.dummyFlashcards
+            }
+        }
+    }
+}
+
+private struct MultipleChoiceFlow: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var currentCard: FlashcardModel
+    @State private var options: [String] = []
+    @State private var completedCount: Int = 0
+
+    let imageName: String
+    let targetCount: Int
+    let vm: FlashcardVM
+    let onFinished: () -> Void
+
+    init(initialCard: FlashcardModel, imageName: String, targetCount: Int, vm: FlashcardVM, onFinished: @escaping () -> Void) {
+        _currentCard = State(initialValue: initialCard)
+        self.imageName = imageName
+        self.targetCount = targetCount
+        self.vm = vm
+        self.onFinished = onFinished
+    }
+
+    var body: some View {
+        MultipleChoice(
+            question: "What sign is being shown?",
+            imageName: imageName,
+            options: options,
+            correctAnswer: currentCard.term.displayName,
+            explanationText: "People often confuse this sign with similar motions. Focus on handshape and movement.",
+            currentCard: currentCard,
+            onNext: { next in
+                advance(to: next)
+            },
+            progress: Double(completedCount) / Double(targetCount)
+        )
+        .onAppear {
+            options = buildOptions(for: currentCard, from: vm.flashcards)
+        }
+        .environment(vm)
+    }
+
+    private func advance(to next: FlashcardModel) {
+        completedCount += 1
+        if completedCount >= targetCount {
+            onFinished()
+            dismiss()
+            return
+        }
+        let nextCard = next
+        currentCard = nextCard
+        options = buildOptions(for: nextCard, from: vm.flashcards)
+    }
+
+    private func buildOptions(for card: FlashcardModel, from pool: [FlashcardModel], count: Int = 4) -> [String] {
+        let distractors = pool
+            .filter { $0.id != card.id }
+            .map { $0.term.displayName }
+            .shuffled()
+            .prefix(max(0, count - 1))
+
+        var opts = Array(distractors)
+        opts.append(card.term.displayName)
+        return Array(Set(opts)).shuffled()
+    }
+}
+
+private struct LearnFlow: View {
+    @State private var currentCard: FlashcardModel
+    @State private var completedCount: Int = 0
+    let targetCount: Int
+    let vm: FlashcardVM
+    let onFinished: () -> Void
+    
+    init(initialCard: FlashcardModel, targetCount: Int, vm: FlashcardVM, onFinished: @escaping () -> Void) {
+        _currentCard = State(initialValue: initialCard)
+        self.targetCount = targetCount
+        self.vm = vm
+        self.onFinished = onFinished
+    }
+    
+    var body: some View {
+        let learnVM = LearnModeVM(flashcard: currentCard)
+        learnVM.onNextCard = { advance() }
+        
+        return LearnModeView(vm: learnVM, progress: Double(completedCount) / Double(max(targetCount, 1)), onClose: onFinished)
+            .id(currentCard.id)
+    }
+    
+    private func advance() {
+        completedCount += 1
+        if completedCount >= targetCount {
+            onFinished()
+            return
+        }
+        if let next = vm.nextCard() { currentCard = next } else { onFinished() }
+    }
+}
+
+#Preview {
+    FlexibleStartCardComponent(
+        context: .learn(.greetings),
+        completed: 0,
+        total: 12,
+        closeAction: {}
+    )
+    .environment(SwiftDataVM())
+}

--- a/Talking Fingers/Flashcards/Views/Components/FlexibleStartCardComponent.swift
+++ b/Talking Fingers/Flashcards/Views/Components/FlexibleStartCardComponent.swift
@@ -4,8 +4,6 @@
 //
 //  Created by Sanvi Adusumilli on 4/16/26.
 //
-//  Builds on StartCardComponent - works for Learn, Exercise, or Daily Challenge
-//
 
 import SwiftUI
 
@@ -60,13 +58,14 @@ enum StartContext {
 }
 
 struct FlexibleStartCardComponent: View {
-    let context: StartContext
+    @State var context: StartContext
     let completed: Int
     let total: Int
     let closeAction: () -> Void
     
     @State private var flashcardVM = FlashcardVM()
     @State private var isActive: Bool = false
+    @State private var showEndScreen: Bool = false
     
     @Environment(SwiftDataVM.self) private var dataVM
 
@@ -76,7 +75,20 @@ struct FlexibleStartCardComponent: View {
 
     var body: some View {
         Group {
-            if isActive {
+            if showEndScreen {
+                EndCardComponent(
+                    context: context,
+                    total: total,
+                    onGoHome: closeAction,
+                    onGoToExercise: {
+                        if case .learn(let cat) = context {
+                            context = .exercise(cat)
+                            showEndScreen = false
+                            isActive = false
+                        }
+                    }
+                )
+            } else if isActive {
                 switch context {
                 case .learn(let category):
                     LearnFlow(
@@ -84,7 +96,7 @@ struct FlexibleStartCardComponent: View {
                         targetCount: total,
                         vm: flashcardVM
                     ) {
-                        isActive = false
+                        showEndScreen = true
                     }
                     
                 case .exercise, .dailyChallenge:
@@ -94,7 +106,7 @@ struct FlexibleStartCardComponent: View {
                         targetCount: total,
                         vm: flashcardVM
                     ) {
-                        isActive = false
+                        showEndScreen = true
                     }
                     .environment(flashcardVM)
                     .environment(dataVM)
@@ -105,7 +117,6 @@ struct FlexibleStartCardComponent: View {
         }
     }
 
-    // MARK: - Start View UI
     private var startView: some View {
         ZStack {
             VStack(spacing: 16) {
@@ -129,8 +140,7 @@ struct FlexibleStartCardComponent: View {
                     
                     Text(context.subtitle)
                         .font(.system(size: 42, weight: .bold))
-                        .foregroundColor(Color(red: 0.58, green: 0.72, blue: 0.85))
-                }
+                        .foregroundColor(context.title == "Learn" ? Color(red: 0.56, green: 0.72, blue: 0.44) : Color(red: 0.58, green: 0.72, blue: 0.85))                }
 
                 Text("\(completed)/\(total) Words Completed")
                     .foregroundColor(.black)
@@ -185,8 +195,6 @@ struct FlexibleStartCardComponent: View {
 }
 
 private struct MultipleChoiceFlow: View {
-    @Environment(\.dismiss) private var dismiss
-
     @State private var currentCard: FlashcardModel
     @State private var options: [String] = []
     @State private var completedCount: Int = 0
@@ -212,22 +220,18 @@ private struct MultipleChoiceFlow: View {
             correctAnswer: currentCard.term.displayName,
             explanationText: "People often confuse this sign with similar motions. Focus on handshape and movement.",
             currentCard: currentCard,
-            onNext: { next in
-                advance(to: next)
-            },
+            onNext: { next in advance(to: next) },
             progress: Double(completedCount) / Double(targetCount)
         )
         .onAppear {
             options = buildOptions(for: currentCard, from: vm.flashcards)
         }
-        .environment(vm)
     }
 
     private func advance(to next: FlashcardModel) {
         completedCount += 1
         if completedCount >= targetCount {
             onFinished()
-            dismiss()
             return
         }
         let nextCard = next
@@ -236,12 +240,7 @@ private struct MultipleChoiceFlow: View {
     }
 
     private func buildOptions(for card: FlashcardModel, from pool: [FlashcardModel], count: Int = 4) -> [String] {
-        let distractors = pool
-            .filter { $0.id != card.id }
-            .map { $0.term.displayName }
-            .shuffled()
-            .prefix(max(0, count - 1))
-
+        let distractors = pool.filter { $0.id != card.id }.map { $0.term.displayName }.shuffled().prefix(max(0, count - 1))
         var opts = Array(distractors)
         opts.append(card.term.displayName)
         return Array(Set(opts)).shuffled()
@@ -282,9 +281,9 @@ private struct LearnFlow: View {
 
 #Preview {
     FlexibleStartCardComponent(
-        context: .learn(.greetings),
+        context: .dailyChallenge,
         completed: 0,
-        total: 12,
+        total: 5,
         closeAction: {}
     )
     .environment(SwiftDataVM())

--- a/Talking Fingers/Flashcards/Views/Components/PopUpComponents/HintPopUpComponent.swift
+++ b/Talking Fingers/Flashcards/Views/Components/PopUpComponents/HintPopUpComponent.swift
@@ -6,44 +6,48 @@
 //
 
 import SwiftUI
- 
+
 struct HintPopUpComponent: View {
     let hintText: String
     var onDismiss: () -> Void
- 
+
     var body: some View {
         VStack(spacing: 23) {
             Text("Hint")
-                .font(.system(size: 27, weight: .bold))
-                .padding(10)
+                .font(.system(size: 32, weight: .bold))
+                .foregroundColor(Color(red: 0.93, green: 0.78, blue: 0.50))
+                .padding(.top, 10)
 
             Text(hintText)
-                .font(.system(size: 23, weight: .bold))
+                .font(.system(size: 22, weight: .bold))
+                .foregroundColor(.black.opacity(0.8))
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 8)
+
             Button {
                 onDismiss()
             } label: {
                 Text("Got it!")
-                    .font(.system(size: 18, weight: .semibold))
+                    .font(.system(size: 20, weight: .bold))
                     .frame(maxWidth: .infinity)
-                    .padding(.vertical, 12)
-                    .background(Color(red: 0.2, green: 0.2, blue: 0.2))
+                    .padding(.vertical, 16)
+                    .background(Color(red: 159/255, green: 192/255, blue: 122/255))
                     .foregroundColor(.white)
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .clipShape(Capsule())
             }
             .padding(.top, 4)
         }
         .padding(28)
         .background(Color.white)
-        .clipShape(RoundedRectangle(cornerRadius: 20))
-        .shadow(radius: 20)
+        .clipShape(RoundedRectangle(cornerRadius: 24))
+        .shadow(color: .black.opacity(0.15), radius: 20)
         .padding(.horizontal, 24)
-        .padding(.bottom, 32)
     }
 }
- 
+
 #Preview {
-    HintPopUpComponent(hintText: "This sign resembles a B shape") {}
+    ZStack {
+        Color.gray.ignoresSafeArea()
+        HintPopUpComponent(hintText: "This sign resembles a B") {}
+    }
 }
- 

--- a/Talking Fingers/Flashcards/Views/DashboardView.swift
+++ b/Talking Fingers/Flashcards/Views/DashboardView.swift
@@ -104,9 +104,7 @@ struct DashboardView: View {
                                             category: item.category,
                                             mode: item.mode,
                                             progress: item.progress,
-                                            backgroundColor: index == 0
-                                            ? Color.blue.opacity(0.2)
-                                            : Color.green.opacity(0.2)
+                                            backgroundColor: Color.blue.opacity(0.15)
                                         )
                                         .frame(width: 180)
                                     }
@@ -236,9 +234,7 @@ struct DashboardView: View {
                                 category: item.category,
                                 mode: item.mode,
                                 progress: item.progress,
-                                backgroundColor: index == 0
-                                ? Color.green.opacity(0.2)
-                                : Color.blue.opacity(0.2)
+                                backgroundColor: Color.blue.opacity(0.15)
                             )
                             .frame(maxWidth: .infinity)
                         }
@@ -311,24 +307,39 @@ private struct InProgressCard: View {
     let mode: String
     let progress: Float
     let backgroundColor: Color
-
+    var iconName: String {
+        switch category {
+        case .alphabet:             return "a.square"
+        case .numbers:              return "number"
+        case .greetings:            return "hand.wave"
+        case .personalInformation:  return "person.text.rectangle"
+        case .family:               return "figure.2.and.child.holdinghands"
+        case .verbs:                return "bolt"
+        case .dateTime:             return "calendar"
+        case .feelingsEmotions:     return "heart"
+        case .locations:            return "mappin.and.ellipse"
+        case .commonDescriptors:    return "text.magnifyingglass"
+        case .commonObjects:        return "cube"
+        }
+    }
+    
     var body: some View {
         VStack(spacing: 12) {
             
             Spacer(minLength: 0)
 
-            Image(category == .greetings ? "greetingsIllustration" : "dummySign")
+            Image(systemName: iconName)
                 .resizable()
                 .scaledToFit()
                 .frame(height: 70)
 
             VStack(spacing: 4) {
                 Text("Continue \(mode)")
-                    .font(.system(size: 14))
+                    .font(.system(size: 15))
                     .foregroundStyle(.secondary)
 
-                Text(category.rawValue)
-                    .font(.system(size: 18, weight: .bold))
+                Text(category.displayName.capitalized)
+                    .font(.system(size: 20, weight: .bold))
                     .multilineTextAlignment(.center)
             }
 

--- a/Talking Fingers/Flashcards/Views/DashboardView.swift
+++ b/Talking Fingers/Flashcards/Views/DashboardView.swift
@@ -174,6 +174,7 @@ struct DashboardView: View {
                     }
                 )
             }
+#if os(iOS)
             .fullScreenCover(item: $activeFlow) { flow in
                 switch flow {
                 case .learn(let category):
@@ -193,6 +194,30 @@ struct DashboardView: View {
                     .environment(dataVM)
                 }
             }
+#else
+            .sheet(item: $activeFlow) { flow in
+                switch flow {
+                case .learn(let category):
+                    FlexibleStartCardComponent(context: .learn(category), completed: 0, total: 12) {
+                        activeFlow = nil
+                    }
+                    .environment(dataVM)
+                    .frame(minWidth: 700, minHeight: 600)
+                case .exercise(let category):
+                    FlexibleStartCardComponent(context: .exercise(category), completed: 0, total: 12) {
+                        activeFlow = nil
+                    }
+                    .environment(dataVM)
+                    .frame(minWidth: 700, minHeight: 600)
+                case .dailyChallenge:
+                    FlexibleStartCardComponent(context: .dailyChallenge, completed: 0, total: 5) {
+                        activeFlow = nil
+                    }
+                    .environment(dataVM)
+                    .frame(minWidth: 700, minHeight: 600)
+                }
+            }
+#endif
         }
     }
     
@@ -209,6 +234,44 @@ struct DashboardView: View {
                 }
             }
             .frame(maxWidth: .infinity)
+        }
+        .background(Color.categoryComponentColor)
+        .popupHost(isPresented: $showModePopup) {
+            ModePopupView(
+                isPresented: $showModePopup,
+                onLearn: {
+                    if let cat = selectedCategoryForPopup {
+                        activeFlow = .learn(cat)
+                    }
+                },
+                onExercise: {
+                    if let cat = selectedCategoryForPopup {
+                        activeFlow = .exercise(cat)
+                    }
+                }
+            )
+        }
+        .sheet(item: $activeFlow) { flow in
+            switch flow {
+            case .learn(let category):
+                FlexibleStartCardComponent(context: .learn(category), completed: 0, total: 12) {
+                    activeFlow = nil
+                }
+                .environment(dataVM)
+                .frame(minWidth: 700, minHeight: 600)
+            case .exercise(let category):
+                FlexibleStartCardComponent(context: .exercise(category), completed: 0, total: 12) {
+                    activeFlow = nil
+                }
+                .environment(dataVM)
+                .frame(minWidth: 700, minHeight: 600)
+            case .dailyChallenge:
+                FlexibleStartCardComponent(context: .dailyChallenge, completed: 0, total: 5) {
+                    activeFlow = nil
+                }
+                .environment(dataVM)
+                .frame(minWidth: 700, minHeight: 600)
+            }
         }
     }
     
@@ -228,7 +291,11 @@ struct DashboardView: View {
                 HStack(spacing: 16) {
                     ForEach(Array(inProgressCategories.enumerated()), id: \.element.category) { index, item in
                         Button {
-                            currentView = item.category.rawValue
+                            if item.mode == "Learn" {
+                                activeFlow = .learn(item.category)
+                            } else {
+                                activeFlow = .exercise(item.category)
+                            }
                         } label: {
                             InProgressCard(
                                 category: item.category,
@@ -247,7 +314,7 @@ struct DashboardView: View {
                     .font(.title)
 
                 Button {
-                    currentView = "DailyChallenge"
+                    activeFlow = .dailyChallenge
                 } label: {
                     DailyChallengeCard(
                         streak: 3,
@@ -263,7 +330,11 @@ struct DashboardView: View {
                 VStack(spacing: 12) {
                     ForEach(allCategories, id: \.self) { category in
                         Button {
-                            currentView = category
+                            let normalized = category.lowercased()
+                            if let cat = TermCategory.allCases.first(where: { $0.rawValue.lowercased() == normalized }) {
+                                selectedCategoryForPopup = cat
+                                showModePopup = true
+                            }
                         } label: {
                             CategoryComponent(title: category)
                                 .frame(maxWidth: .infinity)

--- a/Talking Fingers/Flashcards/Views/DashboardView.swift
+++ b/Talking Fingers/Flashcards/Views/DashboardView.swift
@@ -7,9 +7,31 @@
 
 import SwiftUI
 
+enum ActiveFlow: Identifiable {
+    case learn(TermCategory)
+    case exercise(TermCategory)
+    case dailyChallenge
+    
+    var id: String {
+        switch self {
+        case .learn(let cat): return "learn_\(cat.rawValue)"
+        case .exercise(let cat): return "exercise_\(cat.rawValue)"
+        case .dailyChallenge: return "dailyChallenge"
+        }
+    }
+}
+
 struct DashboardView: View {
     @State private var flashcardVM = FlashcardVM()
     @State private var currentView: String = "Home"
+    
+    // for learn/exercise popup
+    @State private var showModePopup: Bool = false
+    @State private var selectedCategoryForPopup: TermCategory? = nil
+    
+    @State private var activeFlow: ActiveFlow? = nil
+    
+    @Environment(SwiftDataVM.self) private var dataVM
     
     // Compute categories that are in progress (have at least one non-new and non-mastered card)
     private var inProgressCategories: [(category: TermCategory, progress: Float, mode: String)] {
@@ -71,16 +93,20 @@ struct DashboardView: View {
                         ScrollView(.horizontal, showsIndicators: false) {
                             HStack(spacing: 12) {
                                 ForEach(Array(inProgressCategories.enumerated()), id: \.element.category) { index, item in
-                                    NavigationLink {
-                                        Text("Go to \(item.category.rawValue)")
+                                    Button {
+                                        if item.mode == "Learn" {
+                                            activeFlow = .learn(item.category)
+                                        } else {
+                                            activeFlow = .exercise(item.category)
+                                        }
                                     } label: {
                                         InProgressCard(
                                             category: item.category,
                                             mode: item.mode,
                                             progress: item.progress,
                                             backgroundColor: index == 0
-                                                ? Color.blue.opacity(0.2)
-                                                : Color.green.opacity(0.2)
+                                            ? Color.blue.opacity(0.2)
+                                            : Color.green.opacity(0.2)
                                         )
                                         .frame(width: 180)
                                     }
@@ -96,8 +122,8 @@ struct DashboardView: View {
                         .font(.system(size: 26, weight: .bold))
                         .padding(.horizontal)
                     
-                    NavigationLink {
-                        Text("Daily Challenge Page") // later replace with real view
+                    Button {
+                        activeFlow = .dailyChallenge
                     } label: {
                         DailyChallengeCard(
                             streak: 3,
@@ -117,11 +143,12 @@ struct DashboardView: View {
                         GridItem(.flexible(), spacing: 12)
                     ]
                     LazyVGrid(columns: columns, spacing: 12) {
-                        ForEach(allCategories, id: \.self) { category in
-                            NavigationLink {
-                                Text("Category: \(category)")
+                        ForEach(TermCategory.allCases, id: \.self) { category in
+                            Button {
+                                selectedCategoryForPopup = category
+                                showModePopup = true
                             } label: {
-                                CategoryComponent(title: category)
+                                CategoryComponent(title: category.displayName)
                             }
                             .buttonStyle(.plain)
                         }
@@ -133,6 +160,41 @@ struct DashboardView: View {
                 .padding(.top, 8)
             }
             .background(Color.categoryComponentColor)
+            
+            .popupHost(isPresented: $showModePopup) {
+                ModePopupView(
+                    isPresented: $showModePopup,
+                    onLearn: {
+                        if let cat = selectedCategoryForPopup {
+                            activeFlow = .learn(cat)
+                        }
+                    },
+                    onExercise: {
+                        if let cat = selectedCategoryForPopup {
+                            activeFlow = .exercise(cat)
+                        }
+                    }
+                )
+            }
+            .fullScreenCover(item: $activeFlow) { flow in
+                switch flow {
+                case .learn(let category):
+                    FlexibleStartCardComponent(context: .learn(category), completed: 0, total: 12) {
+                        activeFlow = nil
+                    }
+                    .environment(dataVM)
+                case .exercise(let category):
+                    FlexibleStartCardComponent(context: .exercise(category), completed: 0, total: 12) {
+                        activeFlow = nil
+                    }
+                    .environment(dataVM)
+                case .dailyChallenge:
+                    FlexibleStartCardComponent(context: .dailyChallenge, completed: 0, total: 5) {
+                        activeFlow = nil
+                    }
+                    .environment(dataVM)
+                }
+            }
         }
     }
     
@@ -359,4 +421,5 @@ private struct DailyChallengeCard: View {
 
 #Preview {
     DashboardView()
+        .environment(SwiftDataVM())
 }

--- a/Talking Fingers/Flashcards/Views/LearnModeView.swift
+++ b/Talking Fingers/Flashcards/Views/LearnModeView.swift
@@ -8,83 +8,107 @@
 import SwiftUI
 
 struct LearnModeView: View {
-    @StateObject var vm: LearnModeVM
+    @ObservedObject var vm: LearnModeVM
     var progress: Double
-
-    // Add this closure so the presenter can control dismissal.
     var onClose: () -> Void = {}
-
-    @State private var showHint = false
+    
+    @State private var showHintPopup: Bool = false
 
     var body: some View {
         ZStack {
-            // Main content
-            VStack(spacing: 20) {
+            Color.white.ignoresSafeArea()
 
-                header
+            VStack(spacing: 0) {
+                topBar
 
-                Text(vm.word)
-                    .font(.system(size: 45, weight: .bold))
+                VStack(spacing: 20) {
+                    Text(vm.word)
+                        .font(.system(size: 45, weight: .bold))
+                        .padding(.top, 10)
 
-                imageArea
-                    .frame(maxHeight: .infinity)
+                    imageArea
+                        .frame(maxHeight: .infinity)
 
-                Spacer()
+                    Spacer()
 
-                mainButton
+                    mainButton
+                        .padding(.bottom, 20)
+                }
+                .padding(.horizontal, 20)
             }
-            .padding(.top)
-            .padding(.horizontal)
         }
-        .popupHost(isPresented: $showHint) {
+        .popupHost(isPresented: $showHintPopup) {
             HintPopUpComponent(
-                hintText: /* vm.hintText ?? */ "This sign resembles a B shape"
+                hintText: "This sign resembles a B shape"
             ) {
-                showHint = false
+                showHintPopup = false
+                if vm.state == .showingHint {
+                    vm.tapHint()
+                }
             }
         }
     }
 }
 
 extension LearnModeView {
-    var header: some View {
-        HStack {
-            Button {
-                // exit view
-                onClose()
-            } label: {
-                Image(systemName: "xmark.circle.fill")
-                    .font(.title2)
-                    .foregroundStyle(.gray)
+    private var topBar: some View {
+        VStack(spacing: 12) {
+            HStack {
+                Button {
+                    onClose()
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "rectangle.portrait.and.arrow.right")
+                            .font(.system(size: 16, weight: .medium))
+                        Text("Leave")
+                            .font(.system(size: 16, weight: .medium))
+                    }
+                    .foregroundColor(.gray)
+                }
+                .buttonStyle(.plain)
+
+                Spacer()
             }
+            .padding(.horizontal, 20)
+            .padding(.top, 12)
+            
+            HStack(spacing: 12) {
+                GeometryReader { geo in
+                    ZStack(alignment: .leading) {
+                        Capsule()
+                            .fill(Color(red: 0.88, green: 0.92, blue: 0.96))
 
-            ProgressView(value: progress)
-                .progressViewStyle(.linear)
+                        Capsule()
+                            .fill(Color(red: 0.30, green: 0.55, blue: 0.85))
+                            .frame(width: geo.size.width * CGFloat(progress))
+                    }
+                }
+                .frame(height: 10)
 
-            Spacer()
+                Image(systemName: "line.3.horizontal")
+                    .font(.system(size: 20, weight: .medium))
+                    .foregroundColor(.black)
+            }
+            .padding(.horizontal, 20)
         }
-        .padding(.horizontal)
+        .padding(.top, 10)
     }
 
     var imageArea: some View {
         ZStack(alignment: .topTrailing) {
-
             displayedImage
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-            // Show hint icon ONLY when camera is showing
             if vm.showingCamera {
                 hintButton
             }
         }
-        .frame(maxHeight: .infinity)
-        .background(.white)
+        .background(Color.white)
         .clipShape(RoundedRectangle(cornerRadius: 16))
         .overlay(
             RoundedRectangle(cornerRadius: 16)
                 .stroke(Color.gray.opacity(0.3), lineWidth: 1)
         )
-        .padding(.horizontal)
     }
 
     var displayedImage: some View {
@@ -104,7 +128,8 @@ extension LearnModeView {
 
     var hintButton: some View {
         Button {
-            showHint = true
+            vm.tapHint()
+            showHintPopup = true
         } label: {
             Image(systemName: "lightbulb.fill")
                 .font(.system(size: 30))
@@ -123,11 +148,15 @@ extension LearnModeView {
         } label: {
             Text(vm.buttonText)
                 .font(.system(size: 20, weight: .semibold))
+                .foregroundColor(.white)
                 .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+                .background(
+                    RoundedRectangle(cornerRadius: 14)
+                        .fill(vm.buttonColor)
+                )
         }
-        .buttonStyle(.borderedProminent)
-        .tint(vm.buttonColor)
-        .padding(.horizontal)
+        .buttonStyle(.plain)
     }
 }
 


### PR DESCRIPTION
Made a bunch of changes so DashboardView and Learn, Exercise, Daily Review Queue flows are closer to Figma including:
-added on to StartCardComponent in FlexibleStartCardComponent
-tried to make the Home page look closer to Figma
-updated hint pop-up
-created end screen for daily review, learn, exercise flows
-linked daily review queue
-linked categories to mode pop-up

Still a lot of dummy data being used though vs actual logic.